### PR TITLE
MOVED MOST OF THE LOGIC TO UPDATE EXISTING OAUTH USERS FROM SIGNUP FORM INTO NEW METHOD ON 'UserSchema'

### DIFF
--- a/backend/controllers/users.js
+++ b/backend/controllers/users.js
@@ -6,7 +6,7 @@ const { ROOT_URL } = require('../config/root-urls');
 // Register a new user
 exports.signup = (req, res) => {
   const { username, password, email } = req.body;
-  const newUserInfo = { username, password, email }
+  const newUserInfo = { username, password, email };
 
 	User.findOne({ 'local.email': email }).then((existingUser) => {
 		// If user with that email exists

--- a/backend/models/userModel.js
+++ b/backend/models/userModel.js
@@ -1,8 +1,6 @@
 const mongoose = require('mongoose');
 const bcrypt = require('bcrypt');
 
-const { makeToken } = require('../config/passport-setup');
-
 const saltRounds = 11;
 
 const UserSchema = new mongoose.Schema({
@@ -158,8 +156,8 @@ UserSchema.methods.newPassword = async function(password) {
 UserSchema.methods.linkAccounts = async function (userModel={}, userInfo={}) {
   try {
     const { username, password, email } = userInfo;
-    const newPassword = await this.newPassword(password)
-    const target = { 'local.email': email }
+    const newPassword = await this.newPassword(password);
+    const target = { 'local.email': email };
     const update = {
       local: { email, username, password: newPassword }
     };


### PR DESCRIPTION
- controllers/users.js
- models/userModel.js
  - the new methods name is 'linkAccounts'

# Description

This PR should make it easier to know what the `signup` route is attempting to do if a user already has an existing account through one of the OAuth strategies and is now attempting to signup with the landing page form.

## Type of change

Please delete options that are not relevant.

- [x] Refactor

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Create a new account only using one of the OAuth strategies (Google, Facebook, GitHub)
- Now try to create a new account with the same email as used for the OAuth strategy
- Check the database and the account should now have a `password` field that did not exist prior to signing up with the landing page form

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes